### PR TITLE
Implement tRPC manually for Next's App Router structure.

### DIFF
--- a/app/Chat/index.tsx
+++ b/app/Chat/index.tsx
@@ -80,6 +80,16 @@ export const Chat = () => {
     },
   });
 
+  /*
+   * You can uncomment this stub to replace the actual call
+   * if you get stuck and just need the page to render.
+
+  const generatedTextMutation = {
+    mutate: (opts) => { console.log(opts) }
+  }
+
+   */
+
   // const resetMutation = api.ai.reset.useMutation();
 
   const handleUpdate = (prompt: string) => {

--- a/app/server/api/routers/ai.tsx
+++ b/app/server/api/routers/ai.tsx
@@ -12,3 +12,7 @@ export const aiRouter = createTRPCRouter({
       };
     }),
 });
+
+// Exporting just the type data to prevent bundling
+// server-side code into the client.
+export type aiRouterType = typeof aiRouter;

--- a/utils/trpc.ts
+++ b/utils/trpc.ts
@@ -1,0 +1,4 @@
+import { createTRPCReact } from '@trpc/react-query';
+import type { aiRouterType } from '../server/api/routers/ai';
+ 
+export const trpc = createTRPCReact<aiRouterType>();


### PR DESCRIPTION
👋 This change implements the tRPC context provider by (roughly) following the [React Query setup docs](https://trpc.io/docs/client/react).

This change is necessary to get tRPC working due to the official docs being a weird mix of Next's App Router & Pages Router approaches. It _may_ be possible to use the built-in Next integration tools to work with the App Router, but investigations to this end should be timeboxed.

Extra context [on Loom](https://www.loom.com/share/3122faf066ea4beb9906d500457b1202?sid=cb0d2737-5cff-4981-b20f-7097214757d1) (~6 mins)